### PR TITLE
Update Dockerfile to allow building of artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ qtcreator-*
 # Colcon custom files
 COLCON_IGNORE
 AMENT_IGNORE
+
+# Build Artifacts
+*.tar

--- a/build_dev_image.sh
+++ b/build_dev_image.sh
@@ -4,4 +4,5 @@ docker build \
     -t umrt-ros-dev \
     --build-arg USERNAME=${USER} \
     -f Dockerfile \
+    --target dev_image \
     .

--- a/build_robot_artifact.sh
+++ b/build_robot_artifact.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "Building image..."
+docker build \
+    -t umrt-ros-robot \
+    --build-arg USERNAME=${USER} \
+    --target build_artifact \
+    --platform linux/arm64 \
+    -f Dockerfile \
+    . \
+    "$@"
+
+echo -ne "Saving image...\t"
+docker image save umrt-ros-robot -o umrt-ros-robot.tar
+echo "Done!"
+


### PR DESCRIPTION
This PR adds the ability to build tarballs of the docker image that can be copied onto the rover for convenient updates.

The Dockerfile uses the most recent commit to main for robot builds.