### PR TITLE
Add Motor Control to ROS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ CMD ["/bin/bash"]
 
 FROM robot_image AS build_artifact
 
-ADD https://github.com/UMRoboticsTeam/umrt-ros.git /workspace
+ADD . /workspace
 
 WORKDIR /workspace
 ENV SHELL=/bin/bash
@@ -126,7 +126,12 @@ RUN rosdep update
 RUN apt update
 
 RUN rosdep install --from-paths /workspace/src --ignore-src --rosdistro=humble -y
-RUN source /opt/ros/humble/setup.bash && ./build.sh
+
+RUN rm -rf /workspace
+
+# TODO: Look into what exactly is failing on builds of depthai-examples
+# only on Dockerfiles. -njreichert
+# RUN source /opt/ros/humble/setup.bash && ./build.sh
 
 CMD ["/bin/bash"]
 

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -236,7 +236,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   // wheels on the "other side".
   // 
   // Obviously this is horrible but is the best we have right now. -njreichert 2024-07-22
-  if (channel > 2)
+  if (channel >= 2)
   {
     linear_wheel_speed = -1 * linear_wheel_speed;
   }

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -226,6 +226,21 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   // Between -1 and 1 m/s by definition in diffbot_controllers.yaml.
   double linear_wheel_speed = std::clamp(angular_speed * this->wheel_radius_, -1.0, 1.0);
 
+  // HACK ALERT!!!!!!!!!!!!!!!
+  // This assumes the following:
+  // 1. Joints are passed in the following order: left wheel, left wheel, right wheel, right wheel
+  // 2. Servo outputs are wired in the EXACT SAME ORDER AS IN ASSUMPTION 1, STARTING AT PORT 0!
+  //
+  // Since a linear wheel speed that is positive results in wheels spinning in
+  // the same direction (i.e.: Reverse on the other side), we need to reverse 
+  // wheels on the "other side".
+  // 
+  // Obviously this is horrible but is the best we have right now. -njreichert 2024-07-22
+  if (channel > 2)
+  {
+    linear_wheel_speed = -1 * linear_wheel_speed;
+  }
+
   // Typical PWM Servo control assumes:
   // - 1.0 == Full reverse
   // - 1.5 == Neutral / stopped

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -228,7 +228,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
 
   // HACK ALERT!!!!!!!!!!!!!!!
   // This assumes the following:
-  // 1. Joints are passed in the following order: left wheel, left wheel, right wheel, right wheel
+  // 1. Joints are passed in the following order: LF, RF, LB, RB
   // 2. Servo outputs are wired in the EXACT SAME ORDER AS IN ASSUMPTION 1, STARTING AT PORT 0!
   //
   // Since a linear wheel speed that is positive results in wheels spinning in
@@ -236,7 +236,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   // wheels on the "other side".
   // 
   // Obviously this is horrible but is the best we have right now. -njreichert 2024-07-22
-  if (channel >= 2)
+  if (channel % 2 == 1)
   {
     linear_wheel_speed = -1 * linear_wheel_speed;
   }

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
@@ -73,7 +73,7 @@ public:
   hardware_interface::return_type write(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
-  void set_pwm_wheel_speed(int channel, double angular_speed);
+  hardware_interface::return_type set_pwm_wheel_speed(int channel, double angular_speed);
 
 private:
   // Parameters for the DiffBot simulation

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
@@ -79,9 +79,12 @@ public:
   hardware_interface::CallbackReturn on_error(
     const rclcpp_lifecycle::State &previous_state) override;
 
-  hardware_interface::return_type set_pwm_wheel_speed(int channel, double angular_speed);
-
 private:
+  hardware_interface::return_type set_pwm_wheel_speed(
+    int channel, double angular_speed);
+
+  hardware_interface::return_type try_to_reset_wheels();
+
   // Parameters for the DiffBot simulation
   double hw_start_sec_;
   double hw_stop_sec_;

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
@@ -34,6 +34,8 @@
 
 #include "PiPCA9685/PCA9685.h"
 
+#include "ros2_control_demo_example_2/wheel_info.hpp"
+
 // This is a hacky workaround to get velocity commands working on the robot. we
 // are provided per-wheel angular velocitites, which we convert to a +/- 1 m/s
 // velocity internally, and then scale that to a pulse width between 1 and 2 ms.
@@ -87,9 +89,7 @@ private:
   double wheel_radius_;
 
   // Store the command for the simulated robot
-  std::vector<double> hw_commands_;
-  std::vector<double> hw_positions_;
-  std::vector<double> hw_velocities_;
+  std::vector<WheelInfo> wheels;
 
   PiPCA9685::PCA9685 pwm_device_;
 };

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
@@ -75,6 +75,10 @@ public:
   hardware_interface::return_type write(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
+  ROS2_CONTROL_DEMO_EXAMPLE_2_PUBLIC
+  hardware_interface::CallbackReturn on_error(
+    const rclcpp_lifecycle::State &previous_state) override;
+
   hardware_interface::return_type set_pwm_wheel_speed(int channel, double angular_speed);
 
 private:

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/wheel_info.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/wheel_info.hpp
@@ -1,0 +1,8 @@
+#include <string>
+
+struct WheelInfo {
+    std::string name; // Name as passed in yaml file.
+    double command; // Current commanded position.
+    double velocity; // Current velocity command.
+    double position; // Dummy value. TODO: Either put encoders in or remove. -njreichert
+};


### PR DESCRIPTION
Add a basic driver for the PCA9685 Motor Driver based on example code in [ros-controls/ros2_control_demos](https://github.com/ros-controls/ros2_control_demos).

Third-party code used:
- PiPCA9685 (MIT, License [here](https://github.com/UMRoboticsTeam/umrt-ros/blob/main/src/example_2/PIPCA9685_LICENSE)
- ros2_control_demos (Apache-2.0)

Areas for improvement:
- Better error handling - Currently we retry sending motor commands but isn't robust
- Motor feedback - Requires hardware changes