### PR TITLE
CAN motor control

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ ARG USERNAME=USERNAME
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
-# Used for depthai stuff. -njreichert
-COPY requirements.txt /opt/app/requirements.txt
-
 # Environment Variables
 ENV WS=/workspace
 
@@ -58,6 +55,9 @@ RUN apt install -y \
 	libcairo2-dev \
 	libgirepository1.0-dev 
 
+RUN apt install -y  ros-humble-ros2-socketcan
+
+
 # ROS2 Dependencies
 # TODO: What does this do on the 
 # RUN apt install -y --no-install-recommends \
@@ -71,6 +71,13 @@ RUN apt-get update && apt-get install -y \
     libcairo2-dev \
     libgirepository1.0-dev
 RUN pip install meson
+
+# Used for depthai stuff. -njreichert
+COPY requirements.txt /opt/app/requirements.txt
+
+# Used for depthai stuff. -njreichert
+COPY requirements.txt /opt/app/requirements.txt
+
 
 # Setup
 RUN pip install -r /opt/app/requirements.txt
@@ -89,8 +96,8 @@ RUN apt install -y \
 	# Visualization and simulation tools. -njreichert
 	ros-humble-rviz2 \
 	ros-humble-joint-state-publisher-gui \
-    ros-humble-gazebo-ros-pkgs \
-    ros-humble-gazebo-ros2-control \
+        ros-humble-gazebo-ros-pkgs \
+        ros-humble-gazebo-ros2-control \
 	# Tools for working with / connecting to joysticks & gamepads. -njreichert
 	joystick \
 	jstest-gtk \
@@ -98,7 +105,17 @@ RUN apt install -y \
 	# ROS2 Joystick utilities. -njreichert
 	ros-humble-joy \
 	ros-humble-joy-teleop \
-	ros-humble-teleop-twist-joy
+	ros-humble-teleop-twist-joy \
+        # Foxglove for viewing ROS topics
+	ros-humble-foxglove-bridge
+
+# CAN Stuff
+
+RUN apt update &&\
+    apt install software-properties-common -y &&\
+    add-apt-repository ppa:lely/ppa -y &&\
+    apt update &&\
+    apt install net-tools iproute2 can-utils kmod liblely-coapp-dev liblely-co-tools python3-dcf-tools -y
 
 # Create the user
 RUN groupadd --gid $USER_GID $USERNAME \

--- a/build_dev_image.sh
+++ b/build_dev_image.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
-docker build \
-    -t umrt-ros-dev \
-    --build-arg USERNAME=${USER} \
-    -f Dockerfile \
-    --target dev_image \
-    .
+#docker build \
+#    -t umrt-ros-dev \
+#    --build-arg USERNAME=${USER} \
+#    -f Dockerfile \
+#    --target dev_image \
+#    .
+
+docker buildx build \
+	--platform linux/amd64 \
+	-t umrt-ros-dev \
+	--build-arg USERNAME=${USER} \
+	-f Dockerfile \
+	--target dev_image \
+	.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyGObject==3.46.0
+#PyGObject==3.46.0
 depthai==2.24.0.0
 opencv-python
 pyserial

--- a/src/example_2/CMakeLists.txt
+++ b/src/example_2/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
   rclcpp
   rclcpp_lifecycle
+  ros2_socketcan
 )
 
 # find dependencies
@@ -37,7 +38,10 @@ $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/hardware/include>
 $<INSTALL_INTERFACE:include/ros2_control_demo_example_2>
 )
 
-target_link_libraries(ros2_control_demo_example_2 PUBLIC i2c)
+target_link_libraries(ros2_control_demo_example_2
+        PUBLIC
+        i2c
+)
 
 ament_target_dependencies(
   ros2_control_demo_example_2 PUBLIC

--- a/src/example_2/bringup/launch/diffbot.launch.py
+++ b/src/example_2/bringup/launch/diffbot.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_controllers],
+        parameters=[robot_controllers, {'update_rate': 100}], # Update Rate set for 100Hz for non overflowing CANbus
         output="both",
         remappings=[
             ("~/robot_description", "/robot_description"),

--- a/src/example_2/bringup/launch/diffbot.launch.py
+++ b/src/example_2/bringup/launch/diffbot.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_controllers, {'update_rate': 100}], # Update Rate set for 100Hz for non overflowing CANbus
+        parameters=[robot_controllers, {'update_rate': 20}], # Update Rate set for 20Hz cause two hunniiiiid
         output="both",
         remappings=[
             ("~/robot_description", "/robot_description"),

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -255,7 +255,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   constexpr int16_t SCALE = 1000;  // convert m/s to mm/s = 1000
 
   std::vector<int16_t> speeds_mps = {0, 0, 0, 0};
-  for (size_t i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; i++) {
     double wheel_mps = wheels[i].command;
 
     speeds_mps[i] = static_cast<int16_t>(std::round(wheel_mps * SCALE));
@@ -266,7 +266,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   //Build agreed upon Payload: 4, 16 bit ints, each one for a motor
   //[FL_lo, FL_hi, FR_lo, FR_hi, RL_lo, RL_hi, RR_lo, RR_hi]
   std::array<uint8_t, 8> payload{};
-  for (size_t i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; i++) {
     payload[i * 2] = static_cast<uint8_t>(speeds_mps[i] & 0xFF);
     payload[i * 2 + 1] = static_cast<uint8_t>((speeds_mps[i] >> 8) & 0xFF);
   }

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -254,7 +254,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   }
 
   //Send over CAN
-  drivers::socketcan::CanId can_id(0xFF10, 0, drivers::socketcan::FrameType::DATA, drivers::socketcan::StandardFrame);
+  drivers::socketcan::CanId can_id(0xFF10, 0, drivers::socketcan::FrameType::DATA, drivers::socketcan::ExtendedFrame);
 
   try {
     this->can_sender->send(payload.data(), payload.size(), can_id);

--- a/src/example_2/hardware/diffbot_system.cpp
+++ b/src/example_2/hardware/diffbot_system.cpp
@@ -254,7 +254,7 @@ hardware_interface::return_type ros2_control_demo_example_2::DiffBotSystemHardwa
   }
 
   //Send over CAN
-  drivers::socketcan::CanId can_id(0x126, 0, drivers::socketcan::FrameType::DATA, drivers::socketcan::StandardFrame);
+  drivers::socketcan::CanId can_id(0xFF10, 0, drivers::socketcan::FrameType::DATA, drivers::socketcan::StandardFrame);
 
   try {
     this->can_sender->send(payload.data(), payload.size(), can_id);

--- a/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
+++ b/src/example_2/hardware/include/ros2_control_demo_example_2/diffbot_system.hpp
@@ -32,7 +32,7 @@
 
 #include "ros2_control_demo_example_2/visibility_control.h"
 
-#include "PiPCA9685/PCA9685.h"
+#include <ros2_socketcan/socket_can_sender.hpp>
 
 #include "ros2_control_demo_example_2/wheel_info.hpp"
 
@@ -80,10 +80,9 @@ public:
     const rclcpp_lifecycle::State &previous_state) override;
 
 private:
-  hardware_interface::return_type set_pwm_wheel_speed(
-    int channel, double angular_speed);
-
+  hardware_interface::return_type set_can_wheel_speed(int channel, double angular_speed);
   hardware_interface::return_type try_to_reset_wheels();
+
 
   // Parameters for the DiffBot simulation
   double hw_start_sec_;
@@ -98,7 +97,8 @@ private:
   // Store the command for the simulated robot
   std::vector<WheelInfo> wheels;
 
-  PiPCA9685::PCA9685 pwm_device_;
+  std::unique_ptr<drivers::socketcan::SocketCanSender> can_sender;
+
 };
 
 }  // namespace ros2_control_demo_example_2

--- a/src/example_2/package.xml
+++ b/src/example_2/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>ros2_socketcan</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
@@ -38,6 +39,7 @@
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>xacro</test_depend>
+  <build_depend>ros2_socketcan</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/gpsx/CMakeLists.txt
+++ b/src/gpsx/CMakeLists.txt
@@ -29,8 +29,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 add_executable(gps_node src/gps_node.cpp)
 ament_target_dependencies(gps_node rclcpp std_msgs sensor_msgs)
-rosidl_target_interfaces(gps_node ${PROJECT_NAME} "rosidl_typesupport_cpp")
-
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} rosidl_typesupport_cpp)
+target_link_libraries(gps_node ${cpp_typesupport_target})
 target_include_directories(gps_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/start_container.sh
+++ b/start_container.sh
@@ -12,10 +12,11 @@ docker run \
 	--volume="/tmp/.X11-unix/:/tmp/.X11-unix" \
 	--volume="/dev:/dev" \
 	--device-cgroup-rule="c 189:* rw" \
-	--device /dev/dri \
+	--platform linux/amd64 \
 	--device /dev/input \
-	--rm \
 	--network=host \
+	--cap-add=NET_ADMIN \
+	--rm \
 	--pid=host \
 	--name $2 \
 	$1


### PR DESCRIPTION
CAN motor control change

notes:
1) shit is unorganized, however use of ros2_socketcan is fully integrated and the function used in diffbot example now sends out can frames over the CAN Tx line over can0 on a given system.

2) Controller manager is now set to 20Hz, not 100 due to not requiring that many updates on requested wheel speed.

recommendations:
1) we eventually shall not base off example2 and go on our own path, however we will push that later I would like to think :3 